### PR TITLE
Error with errors

### DIFF
--- a/codec/codec.go
+++ b/codec/codec.go
@@ -113,25 +113,30 @@ func (s *ServerCodec) ReadRequestBody(obj interface{}) error {
 // the response was invalid, the size of the body of the resp is reported as
 // having size zero and is not sent.
 func (s *ServerCodec) WriteResponse(resp *rpc.Response, obj interface{}) error {
-	pb, ok := obj.(proto.Message)
-	if !ok {
-		return fmt.Errorf("%T does not implement proto.Message", obj)
-	}
-
 	// Write the header
 	header := wire.Header{
 		Method: &resp.ServiceMethod,
 		Seq:    &resp.Seq,
 	}
+
 	if resp.Error != "" {
 		header.Error = &resp.Error
 	}
+
 	if err := WriteProto(s.w, &header); err != nil {
-		return nil
+		return err
 	}
 
-	// Write the proto
-	return WriteProto(s.w, pb)
+	if resp.Error == "" {
+		pb, ok := obj.(proto.Message)
+		if !ok {
+			return fmt.Errorf("%T does not implement proto.Message", obj)
+		}
+
+		return WriteProto(s.w, pb)
+	}
+
+	return nil
 }
 
 // Close closes the underlying conneciton.
@@ -202,6 +207,10 @@ func (c *ClientCodec) ReadResponseHeader(resp *rpc.Response) error {
 // is zero, nothing is done (this indicates an error condition, which was
 // encapsulated in the header)
 func (c *ClientCodec) ReadResponseBody(obj interface{}) error {
+	if obj == nil {
+		return nil
+	}
+
 	pb, ok := obj.(proto.Message)
 	if !ok {
 		return fmt.Errorf("%T does not implement proto.Message", obj)

--- a/examples/add/add.go
+++ b/examples/add/add.go
@@ -10,6 +10,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/tls"
+	"errors"
 	"flag"
 	"log"
 	"net"
@@ -30,6 +31,8 @@ type Add struct{}
 // called concurrently, so if the Add structure did have internal state,
 // it should be designed for concurrent access.
 func (Add) Add(in *addservice.AddMessage, out *addservice.SumMessage) error {
+	return errors.New("Math Error")
+
 	out.Z = new(int32)
 	*out.Z = *in.X + *in.Y
 	log.Printf("server: X=%d Y=%d Z=%d", *in.X, *in.Y, *out.Z)


### PR DESCRIPTION
Changed the WriteResponse function to always write the header, and conditionally write a body if there is no error in the rpc.Response.

Changed the ReadResponseBody to not attempt to read the object if it is nil, as the net/rpc Client passes a nil object on error and when there is no pending call (http://golang.org/src/pkg/net/rpc/client.go line
